### PR TITLE
SCRUM-151-docs-updated-image-paths

### DIFF
--- a/docs/BRANCHING-STRATEGY.md
+++ b/docs/BRANCHING-STRATEGY.md
@@ -2,7 +2,7 @@
 
 This repository follows **Trunk Based Development (TBD)** to enable rapid builds, quality delivery through automation, and frictionless feature flow. This strategy supports CI/CD for all frontend and backend services.
 
-![img](./docs/img/image-1.png)
+![img](./img/image-1.png)
 
 ## 📂 Branch Types
 
@@ -36,7 +36,7 @@ This repository follows **Trunk Based Development (TBD)** to enable rapid builds
 
 ---
 
-![img](./docs/img/image-2-ci.png)
+![img](./img/image-2-ci.png)
 
 ## 📌 Release Strategy
 


### PR DESCRIPTION
This pull request includes updates to the `docs/BRANCHING-STRATEGY.md` file to correct image paths. The changes ensure that images are correctly displayed in the documentation.

Documentation updates:

* [`docs/BRANCHING-STRATEGY.md`](diffhunk://#diff-91e4354bef3e0be03ac73cbda7467a46f8ae2b9ba1a8230686149a2b6b911f6fL5-R5): Updated the path for the image from `./docs/img/image-1.png` to `./img/image-1.png`.
* [`docs/BRANCHING-STRATEGY.md`](diffhunk://#diff-91e4354bef3e0be03ac73cbda7467a46f8ae2b9ba1a8230686149a2b6b911f6fL39-R39): Updated the path for the image from `./docs/img/image-2-ci.png` to `./img/image-2-ci.png`.