### PR TITLE
SCRUM-206-Sending Response as JSON in GoogleAuthButton

### DIFF
--- a/src/components/GoogleAuthButton.tsx
+++ b/src/components/GoogleAuthButton.tsx
@@ -27,15 +27,18 @@ const GoogleAuthButton: React.FC = () => {
 
       dispatch(setUserDetails({ email, name, picture }));
 
-      // Send only the token as raw text/plain
       const response = await axios.post(
         "http://localhost:7237/api/User/validategoogleuser",
-        credentialResponse.credential, // Send as a raw string
+        { token: credentialResponse.credential }, // ✅ Send as JSON object
         {
-          headers: { "Content-Type": "application/json" }, // Ensure raw string format
-          validateStatus: (status) => status < 500, // Prevents throwing errors for 4xx responses
-        },
+          headers: {
+            "Content-Type": "application/json"
+          },
+          validateStatus: (status) => status < 500,
+        }
       );
+
+
 
       if (response.status === 200) {
         console.log("Backend validation successful:", response.data);


### PR DESCRIPTION
This pull request updates the `GoogleAuthButton` component to improve the way authentication tokens are sent to the backend. The key change ensures the token is sent as part of a JSON object instead of as a raw string.

### Improvements to API request structure:
* [`src/components/GoogleAuthButton.tsx`](diffhunk://#diff-4cdc3838defb8b406e801f5bd05413344a791687a39ff3def31aef4355c08f6bL30-R42): Modified the `axios.post` request to send the Google authentication token as a JSON object (`{ token: credentialResponse.credential }`) instead of a raw string. This ensures better consistency with JSON-based APIs.