### PR TITLE
SCRUM-158-Updated CD only on push to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,10 +18,11 @@ name: CD - Stage 1 - Deploy to Dockerhub
 
 on:
   # Commented triggers can be uncommented when ready to automate deployment on push events
-  # push:
+  push:
+    branches: [main]
   #   branches: [main, "feature/**"]
-  pull_request:
-    branches: [main]  # Run on PRs targeting main branch
+  # pull_request:
+    # branches: [main]  # Run on PRs targeting main branch
   # Manual trigger with environment selection
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This pull request updates the Continuous Deployment (CD) workflow configuration to enable automatic deployment on pushes to the `main` branch while disabling deployment on pull requests.

Changes to `.github/workflows/cd.yml`:

* Enabled the `push` trigger for the `main` branch to automate deployments when changes are pushed to `main`.
* Commented out the `pull_request` trigger to disable workflow runs for pull requests targeting the `main` branch.CD disabled for pull requests on main