### PR TITLE
SCRUM-156-Ci-linked-with-CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@
 # and can also be manually triggered with environment selection.
 # ======================================================
 
-name: "CD Pipeline - Deploy to Dockerhub"
+name: "CD Pipeline - Deploy Tradeport Frontend to Dockerhub"
 
 on:
   workflow_run:


### PR DESCRIPTION
This pull request updates the name of the continuous deployment (CD) pipeline in the `.github/workflows/cd.yml` file to provide greater clarity about its purpose.

* Updated the pipeline name in `.github/workflows/cd.yml` to specify that it deploys the Tradeport frontend to Dockerhub.