### PR TITLE
SCRUM-156-Renaming CD Dockerhub to CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@
 # and can also be manually triggered with environment selection.
 # ======================================================
 
-name: "CD Pipeline - Deploy Tradeport Frontend to Dockerhub"
+name: "CI Pipeline - Deploy Tradeport Frontend to Dockerhub"
 
 on:
   workflow_run:


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/cd.yml` file. The change updates the workflow name from "CD Pipeline - Deploy Tradeport Frontend to Dockerhub" to "CI Pipeline - Deploy Tradeport Frontend to Dockerhub" to better reflect its purpose.Renaming so that better align with the strategy